### PR TITLE
Add error handling to eMask status notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,10 +11,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application
         android:name=".App"
@@ -40,7 +38,6 @@
         <service
             android:name=".service.CovidService"
             android:enabled="true"
-            android:exported="true"
             android:foregroundServiceType="location">
             <meta-data
                 android:name="longScanForcingEnabled"
@@ -57,20 +54,8 @@
             </intent-filter>
         </receiver>
 
-        <receiver
-            android:name=".receiver.BluetoothStateReceiver"
-            android:enabled="true">
-            <intent-filter>
-                <action android:name="android.bluetooth.adapter.action.STATE_CHANGED"/>
-            </intent-filter>
-        </receiver>
-
-        <receiver android:name=".receiver.LocationStateReceiver">
-            <intent-filter>
-                <action android:name="android.location.PROVIDERS_CHANGED" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-        </receiver>
+        <receiver android:name=".receiver.BluetoothStateReceiver"/>
+        <receiver android:name=".receiver.LocationStateReceiver"/>
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/cz/covid19cz/app/DI.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/DI.kt
@@ -1,10 +1,15 @@
 package cz.covid19cz.app
 
 import android.app.Application
+import android.app.NotificationManager
+import androidx.core.content.getSystemService
 import androidx.room.Room
 import cz.covid19cz.app.bt.BluetoothRepository
 import cz.covid19cz.app.db.*
 import cz.covid19cz.app.db.export.CsvExporter
+import cz.covid19cz.app.receiver.BluetoothStateReceiver
+import cz.covid19cz.app.receiver.LocationStateReceiver
+import cz.covid19cz.app.service.WakeLockManager
 import cz.covid19cz.app.ui.btdisabled.BtDisabledVM
 import cz.covid19cz.app.ui.btenabled.BtEnabledVM
 import cz.covid19cz.app.ui.btonboard.BtOnboardVM
@@ -15,6 +20,7 @@ import cz.covid19cz.app.ui.main.MainVM
 import cz.covid19cz.app.ui.sandbox.SandboxVM
 import cz.covid19cz.app.ui.welcome.WelcomeVM
 import org.koin.android.ext.koin.androidApplication
+import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
@@ -52,8 +58,14 @@ val repositoryModule = module {
     }
 
     single { provideDatabaseRepository(get()) }
-    single { BluetoothRepository(get()) }
+    single { BluetoothRepository(get(), get()) }
     single { SharedPrefsRepository(get()) }
 }
 
-val allModules = listOf(viewModelModule, databaseModule, repositoryModule)
+val appModule = module {
+    single { LocationStateReceiver() }
+    single { BluetoothStateReceiver() }
+    single { WakeLockManager(androidContext().getSystemService()) }
+}
+
+val allModules = listOf(appModule, viewModelModule, databaseModule, repositoryModule)

--- a/app/src/main/kotlin/cz/covid19cz/app/ext/Context.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/ext/Context.kt
@@ -4,13 +4,12 @@ import android.content.Context
 import android.location.LocationManager
 import android.os.Build
 import android.provider.Settings
+import androidx.core.content.getSystemService
 
 fun Context.isLocationEnabled(): Boolean {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         // This is new method provided in API 28
-        val lm =
-            this.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-        lm.isLocationEnabled
+        getSystemService<LocationManager>()?.isLocationEnabled ?: false
     } else {
         // This is Deprecated in API 28
         val mode = Settings.Secure.getInt(

--- a/app/src/main/kotlin/cz/covid19cz/app/receiver/BluetoothStateReceiver.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/receiver/BluetoothStateReceiver.kt
@@ -4,27 +4,14 @@ import android.bluetooth.BluetoothAdapter
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import cz.covid19cz.app.utils.Log
+import cz.covid19cz.app.service.CovidService
 
-class BluetoothStateReceiver : BroadcastReceiver(){
-    override fun onReceive(context: Context?, intent: Intent?) {
-        val action = intent?.getAction()
-
-        if (action.equals(BluetoothAdapter.ACTION_STATE_CHANGED)) {
-            val state = intent?.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
-            when(state) {
-                BluetoothAdapter.STATE_OFF -> {
-                    Log.d("Bluetooth OFF")
-                }
-                BluetoothAdapter.STATE_TURNING_OFF -> {
-
-                }
-                BluetoothAdapter.STATE_ON -> {
-                    Log.d("Bluetooth ON")
-                }
-                BluetoothAdapter.STATE_TURNING_ON -> {
-
-                }
+class BluetoothStateReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (BluetoothAdapter.ACTION_STATE_CHANGED == intent?.action) {
+            when (intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)) {
+                BluetoothAdapter.STATE_OFF -> CovidService.update(context)
+                BluetoothAdapter.STATE_ON -> CovidService.update(context)
             }
 
         }

--- a/app/src/main/kotlin/cz/covid19cz/app/receiver/LocationStateReceiver.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/receiver/LocationStateReceiver.kt
@@ -1,18 +1,18 @@
 package cz.covid19cz.app.receiver
 
-import android.bluetooth.BluetoothAdapter
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import cz.covid19cz.app.service.CovidService
 import cz.covid19cz.app.utils.Log
 
 class LocationStateReceiver : BroadcastReceiver(){
-    override fun onReceive(context: Context?, intent: Intent?) {
-        val action = intent?.getAction()
+    override fun onReceive(context: Context, intent: Intent?) {
+        val action = intent?.action
         Log.d("Location state changed")
 
         if (action.equals("android.location.PROVIDERS_CHANGED")) {
-
+            CovidService.update(context)
         }
     }
 

--- a/app/src/main/kotlin/cz/covid19cz/app/service/CovidService.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/service/CovidService.kt
@@ -1,42 +1,30 @@
 package cz.covid19cz.app.service
 
-import android.annotation.SuppressLint
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
 import android.app.Service
+import android.bluetooth.BluetoothAdapter
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.location.LocationManager
-import android.os.Build
-import android.os.IBinder
-import android.os.PowerManager
-import androidx.core.app.NotificationCompat
+import android.os.*
 import androidx.core.content.ContextCompat
 import cz.covid19cz.app.AppConfig
-import cz.covid19cz.app.R
 import cz.covid19cz.app.bt.BluetoothRepository
-import cz.covid19cz.app.db.ScanResultEntity
-import cz.covid19cz.app.db.DatabaseRepository
 import cz.covid19cz.app.db.SharedPrefsRepository
 import cz.covid19cz.app.ext.execute
 import cz.covid19cz.app.ext.isLocationEnabled
 import cz.covid19cz.app.receiver.BluetoothStateReceiver
 import cz.covid19cz.app.receiver.LocationStateReceiver
-import cz.covid19cz.app.ui.main.MainActivity
+import cz.covid19cz.app.ui.notifications.CovidNotificationManager
 import cz.covid19cz.app.utils.Log
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import org.koin.android.ext.android.inject
 import java.util.concurrent.TimeUnit
 
-
 class CovidService : Service() {
 
     companion object {
-
-        const val CHANNEL_ID = "ForegroundServiceChannel"
         const val ACTION_START = "ACTION_START"
         const val ACTION_STOP = "ACTION_STOP"
         const val ACTION_UPDATE = "ACTION_UPDATE"
@@ -52,16 +40,25 @@ class CovidService : Service() {
             stopIntent.action = ACTION_STOP
             c.startService(stopIntent)
         }
+
+        fun update(c: Context) {
+            val stopIntent = Intent(c, CovidService::class.java)
+            stopIntent.action = ACTION_UPDATE
+            c.startService(stopIntent)
+        }
     }
 
-    lateinit var deviceBuid: String
-    val btUtils by inject<BluetoothRepository>()
-    val db by inject<DatabaseRepository>()
-    val prefs by inject<SharedPrefsRepository>()
+    private val locationStateReceiver by inject<LocationStateReceiver>()
+    private val bluetoothStateReceiver by inject<BluetoothStateReceiver>()
+    private val btUtils by inject<BluetoothRepository>()
+    private val prefs by inject<SharedPrefsRepository>()
+    private val wakeLockManager by inject<WakeLockManager>()
+    private val notificationManager = CovidNotificationManager(this)
 
-    var bleAdvertisingDisposable: Disposable? = null
-    var bleScanningDisposable: Disposable? = null
-    private var wakeLock: PowerManager.WakeLock? = null
+    private var bleAdvertisingDisposable: Disposable? = null
+    private var bleScanningDisposable: Disposable? = null
+
+    private lateinit var deviceBuid: String
 
     override fun onCreate() {
         super.onCreate()
@@ -73,67 +70,32 @@ class CovidService : Service() {
             // null intent is in case service is restarted by system
             ACTION_START, null -> {
                 createNotification()
-
-                startBleAdvertising()
-                startBleScanning()
-                wakeLock(true)
+                turnMaskOn()
+                subscribeToBluetoothAndLocationStates()
+                wakeLockManager.acquire()
             }
             ACTION_STOP -> {
-                wakeLock(false)
+                wakeLockManager.release()
                 stopForeground(true)
                 stopSelf()
             }
             ACTION_UPDATE -> {
                 createNotification()
+                if (isLocationEnabled() && btUtils.isBtEnabled()) {
+                    turnMaskOn()
+                } else {
+                    turnMaskOff()
+                }
             }
         }
         return START_STICKY
     }
 
-    fun createNotification() {
-
-        val btEnabled = btUtils.isBtEnabled()
-        val locationEnabled = isLocationEnabled()
-
-        createNotificationChannel()
-        val notificationIntent = Intent(this, MainActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            0, notificationIntent, 0
-        )
-
-        val title :Int
-        val text : Int
-        val icon :Int
-
-        //TODO: work in progress
-        //if (btEnabled && locationEnabled){
-        if (true){
-            title = R.string.notification_title
-            text = R.string.notification_text
-            icon = R.drawable.ic_notification_normal
-        } else {
-            title = R.string.notification_title_error
-            text = R.string.notification_text_error
-            icon = R.drawable.ic_notification_error
-        }
-
-        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle(getString(title))
-            .setContentText(getString(text))
-            .setSmallIcon(icon)
-            .setContentIntent(pendingIntent)
-            .build();
-        startForeground(1, notification)
-    }
-
     override fun onDestroy() {
-        btUtils.stopScanning()
-        btUtils.stopAdvertising()
-        bleScanningDisposable?.dispose()
-        bleScanningDisposable = null
-        bleAdvertisingDisposable?.dispose()
-        bleAdvertisingDisposable = null
+        wakeLockManager.release()
+        turnMaskOff()
+        unsubscribeFromBluetoothAndLocationStates()
+
         super.onDestroy()
     }
 
@@ -141,117 +103,78 @@ class CovidService : Service() {
         return null
     }
 
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val serviceChannel = NotificationChannel(
-                CHANNEL_ID,
-                getString(R.string.foreground_service_channel),
-                NotificationManager.IMPORTANCE_HIGH
-            )
-            val manager = getSystemService(
-                NotificationManager::class.java
-            )
-            manager.createNotificationChannel(serviceChannel)
-        }
+    private fun turnMaskOn() {
+        startBleAdvertising()
+        startBleScanning()
     }
 
-    fun startBleScanning() {
+    private fun turnMaskOff() {
+        btUtils.stopScanning()
+        btUtils.stopAdvertising()
+
+        bleScanningDisposable?.dispose()
+        bleScanningDisposable = null
+        bleAdvertisingDisposable?.dispose()
+        bleAdvertisingDisposable = null
+    }
+
+    private fun createNotification() {
+        notificationManager.postNotification(btUtils.isBtEnabled(), isLocationEnabled())
+    }
+
+    private fun subscribeToBluetoothAndLocationStates() {
+        val filter = IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION)
+        registerReceiver(locationStateReceiver, filter)
+
+        val btFilter = IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
+        registerReceiver(bluetoothStateReceiver, btFilter)
+    }
+
+    private fun unsubscribeFromBluetoothAndLocationStates() {
+        unregisterReceiver(locationStateReceiver)
+        unregisterReceiver(bluetoothStateReceiver)
+    }
+
+    private fun startBleScanning() {
         bleScanningDisposable = Observable.just(true)
             //Give IU Thread time to clean data
             .delay(1, TimeUnit.SECONDS)
             .map {
-                if (btUtils.isBtEnabled()) {
+                if (btUtils.isBtEnabled() && isLocationEnabled()) {
                     btUtils.startScanning()
                 } else {
-                    createNotification()
                     bleScanningDisposable?.dispose()
                 }
-                return@map it
             }
             .delay(AppConfig.collectionSeconds, TimeUnit.SECONDS)
             .map {
                 btUtils.stopScanning()
-                saveData()
-                return@map it
+                btUtils.saveScansAndDispose()
             }
             .delay(AppConfig.waitingSeconds, TimeUnit.SECONDS)
             .repeat()
-            .execute({
-                btUtils.clearScanResults()
-            }, {
-                Log.e(it)
-            })
+            .execute(
+                { Log.i("Restarting BLE scanning") },
+                { Log.e(it) }
+            )
     }
 
-    fun startBleAdvertising() {
+    private fun startBleAdvertising() {
         bleAdvertisingDisposable = Observable.just(true)
             .delay(1, TimeUnit.SECONDS)
             .map {
                 if (btUtils.isBtEnabled()) {
                     btUtils.startAdvertising(deviceBuid)
                 } else {
-                    createNotification()
                     bleAdvertisingDisposable?.dispose()
                 }
             }
             .delay(AppConfig.advertiseRestartMinutes, TimeUnit.MINUTES)
-            .map {
-                btUtils.stopAdvertising()
-            }
+            .map { btUtils.stopAdvertising() }
             .repeat()
-            .execute({
-                Log.i("Restarting BLE advertising")
-            }, {
-                Log.e(it)
-            })
-    }
-
-    fun saveData() {
-        Log.i("Saving data to database")
-        val tempArray = btUtils.scanResultsList.toTypedArray()
-        for (item in tempArray) {
-            item.calculate()
-            db.add(
-                ScanResultEntity(
-                    0,
-                    item.deviceId,
-                    item.timestampStart,
-                    item.timestampEnd,
-                    item.minRssi,
-                    item.maxRssi,
-                    item.avgRssi,
-                    item.medRssi,
-                    item.rssiCount
-                )
+            .execute(
+                { Log.i("Restarting BLE advertising") },
+                { Log.e(it) }
             )
-        }
-        Log.i("${tempArray.size} records saved")
-    }
-
-    @SuppressLint("InvalidWakeLockTag", "WakelockTimeout")
-    private fun wakeLock(enable: Boolean) {
-        if (enable) {
-            var tag = "$packageName:LOCK"
-
-            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.M && Build.MANUFACTURER == "Huawei") {
-                tag = "LocationManagerService"
-            }
-
-            wakeLock = (getSystemService(Context.POWER_SERVICE) as PowerManager).newWakeLock(
-                PowerManager.PARTIAL_WAKE_LOCK,
-                tag
-            )
-            wakeLock?.let {
-                if (!it.isHeld) {
-                    it.acquire()
-                }
-            }
-        } else {
-            wakeLock?.let {
-                if (it.isHeld) {
-                    it.release()
-                }
-            }
-        }
     }
 }

--- a/app/src/main/kotlin/cz/covid19cz/app/service/WakeLockManager.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/service/WakeLockManager.kt
@@ -1,0 +1,35 @@
+package cz.covid19cz.app.service
+
+import android.annotation.SuppressLint
+import android.os.Build
+import android.os.PowerManager
+import cz.covid19cz.app.BuildConfig
+
+class WakeLockManager(private val powerManager: PowerManager?) {
+
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    @SuppressLint("InvalidWakeLockTag", "WakelockTimeout")
+    fun acquire() {
+        var tag = "${BuildConfig.APPLICATION_ID}:LOCK"
+
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.M && Build.MANUFACTURER == "Huawei") {
+            tag = "LocationManagerService"
+        }
+
+        wakeLock = powerManager?.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, tag)
+        wakeLock?.let {
+            if (!it.isHeld) {
+                it.acquire()
+            }
+        }
+    }
+
+    fun release() {
+        wakeLock?.let {
+            if (it.isHeld) {
+                it.release()
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/cz/covid19cz/app/ui/notifications/CovidNotificationManager.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/ui/notifications/CovidNotificationManager.kt
@@ -1,0 +1,101 @@
+package cz.covid19cz.app.ui.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.bluetooth.BluetoothAdapter
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import androidx.core.content.getSystemService
+import cz.covid19cz.app.R
+import cz.covid19cz.app.service.CovidService
+import cz.covid19cz.app.ui.main.MainActivity
+
+class CovidNotificationManager(private val service: CovidService) {
+
+    companion object {
+        const val SERVICE_CHANNEL_ID = "ForegroundServiceChannel"
+        const val ALERT_CHANNEL_ID = "ForegroundServiceAlertChannel"
+        const val NOTIFICATION_ID = 1
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channels = listOf(
+                NotificationChannel(
+                    SERVICE_CHANNEL_ID,
+                    service.getString(R.string.foreground_service_channel),
+                    NotificationManager.IMPORTANCE_LOW
+                ),
+                NotificationChannel(
+                    ALERT_CHANNEL_ID,
+                    service.getString(R.string.foreground_service_alert_channel),
+                    NotificationManager.IMPORTANCE_HIGH
+                ).apply { enableVibration(true) }
+            )
+            val manager = service.getSystemService<NotificationManager>()
+            channels.forEach {
+                manager?.createNotificationChannel(it)
+            }
+        }
+    }
+
+    fun postNotification(bluetoothEnabled: Boolean, locationEnabled: Boolean) {
+        createNotificationChannel()
+
+        val builder = NotificationCompat.Builder(service, SERVICE_CHANNEL_ID)
+
+        @StringRes val title: Int
+        @StringRes val text: Int
+        @DrawableRes val icon: Int
+        @ColorRes val color: Int
+        val notificationIntent = Intent(service, MainActivity::class.java)
+
+        if (bluetoothEnabled && locationEnabled) {
+            title = R.string.notification_title
+            text = R.string.notification_text
+            icon = R.drawable.ic_notification_normal
+            color = R.color.green
+        } else {
+            title = R.string.notification_title_error
+            icon = R.drawable.ic_notification_error
+            color = R.color.red
+
+            builder.setChannelId(ALERT_CHANNEL_ID)
+            builder.setStyle(NotificationCompat.BigTextStyle())
+
+            @StringRes val actionText: Int?
+            val actionIntent: Intent
+            if (!bluetoothEnabled) {
+                text = R.string.notification_text_bluetooth_disabled
+                actionIntent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
+                actionText = R.string.notification_action_enabled_bluetooth
+            } else {
+                text = R.string.notification_text_location_disabled
+                actionIntent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+                actionText = R.string.notification_action_enabled_location
+            }
+            val actionPendingIntent = PendingIntent.getActivity(service, 0, actionIntent, 0)
+            builder.addAction(0, service.getString(actionText), actionPendingIntent)
+        }
+
+        val notificationPendingIntent =
+            PendingIntent.getActivity(service, 0, notificationIntent, 0)
+
+        with(service) {
+            builder.setContentTitle(getString(title))
+                .setContentText(getString(text))
+                .setSmallIcon(icon)
+                .setColor(ContextCompat.getColor(this, color))
+                .setContentIntent(notificationPendingIntent)
+                .build()
+                .run { startForeground(NOTIFICATION_ID, this) }
+        }
+    }
+}

--- a/app/src/main/kotlin/cz/covid19cz/app/ui/sandbox/SandboxFragment.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/ui/sandbox/SandboxFragment.kt
@@ -21,11 +21,10 @@ class SandboxFragment :
 
     companion object {
         const val REQUEST_BT_ENABLE = 1000
-        const val REQUEST_PERMISSION_FINE_LOCATION = 1001
     }
 
-    lateinit var rxPermissions: RxPermissions
-    val compositeDisposable = CompositeDisposable()
+    private lateinit var rxPermissions: RxPermissions
+    private val compositeDisposable = CompositeDisposable()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,16 +73,14 @@ class SandboxFragment :
         tryStartBtService()
     }
 
-    fun tryStartBtService() {
+    private fun tryStartBtService() {
         if (viewModel.bluetoothRepository.hasBle(requireContext())) {
             if (!viewModel.bluetoothRepository.isBtEnabled()) {
                 navigate(R.id.action_nav_sandbox_to_nav_bt_disabled)
                 return
             }
             compositeDisposable.add(rxPermissions
-                .request(
-                    Manifest.permission.ACCESS_FINE_LOCATION
-                )
+                .request(Manifest.permission.ACCESS_FINE_LOCATION)
                 .subscribe { granted: Boolean ->
                     if (granted) {
                         startBtService()
@@ -98,7 +95,7 @@ class SandboxFragment :
         }
     }
 
-    fun stopService() {
+    private fun stopService() {
         CovidService.stopService(requireContext())
     }
 
@@ -110,7 +107,7 @@ class SandboxFragment :
         }
     }
 
-    fun startBtService() {
+    private fun startBtService() {
         CovidService.startService(requireContext())
         viewModel.confirmStart()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,8 +5,13 @@
     <string name="notification_text">Právě pomáháte chránit sebe i ostatní</string>
 
     <string name="notification_title_error">eRouška neběží</string>
-    <string name="notification_text_error">Pokračujte podle instrukcí v aplikaci</string>
+    <string name="notification_text_bluetooth_disabled">Pro správnou funkci eRoušky je třeba zapnout bluetooth</string>
+    <string name="notification_text_location_disabled">Pro správnou funkci eRoušky je třeba zapnout polohové služby</string>
+
+    <string name="notification_action_enabled_bluetooth">Zapnout bluetooth</string>
+    <string name="notification_action_enabled_location">Zapnout polohové služby</string>
     <string name="foreground_service_channel">Služba na pozadí</string>
+    <string name="foreground_service_alert_channel">Důležitá upozornění</string>
 
     <string name="help_toolbar_title">Jak to funguje</string>
     <string name="bluetooth_toolbar_title">Hledání zařízení</string>


### PR DESCRIPTION
Changes:
- The notification will show an error state whenever:
1. Bluetooth is disabled
2. Location services are disabled
- When in error state it will now also show an action that will allow the user to fix the error and
deploy the mask again.
- Normal ongoing notification has low priority so it doesn't beep and goes lower in the not. list
- Error state has still high importance so it should beep and vibrate (according to the users settings)
- Bt is now not autoenabled but requires user action
- App listens to Location Provider and BT state changes and shows the error (and disables mask) when
one or the other is disabled
- I refactored notification code and put it outside of the service