### PR TITLE
Screen-off scan check

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,8 @@
 
         <receiver android:name=".receiver.BluetoothStateReceiver"/>
         <receiver android:name=".receiver.LocationStateReceiver"/>
+        <receiver android:name=".receiver.ScreenStateReceiver"/>
+
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"

--- a/app/src/main/kotlin/cz/covid19cz/app/DI.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/DI.kt
@@ -12,14 +12,15 @@ import cz.covid19cz.app.db.export.CsvExporter
 import cz.covid19cz.app.receiver.BatterSaverStateReceiver
 import cz.covid19cz.app.receiver.BluetoothStateReceiver
 import cz.covid19cz.app.receiver.LocationStateReceiver
+import cz.covid19cz.app.receiver.ScreenStateReceiver
 import cz.covid19cz.app.service.WakeLockManager
 import cz.covid19cz.app.ui.btdisabled.BtDisabledVM
 import cz.covid19cz.app.ui.dashboard.DashboardVM
-import cz.covid19cz.app.ui.onboarding.PermissionsOnboardingVM
 import cz.covid19cz.app.ui.dbexplorer.DbExplorerVM
 import cz.covid19cz.app.ui.help.HelpVM
 import cz.covid19cz.app.ui.login.LoginVM
 import cz.covid19cz.app.ui.main.MainVM
+import cz.covid19cz.app.ui.onboarding.PermissionsOnboardingVM
 import cz.covid19cz.app.ui.sandbox.SandboxVM
 import cz.covid19cz.app.ui.welcome.WelcomeVM
 import org.koin.android.ext.koin.androidApplication
@@ -68,13 +69,13 @@ val repositoryModule = module {
 val appModule = module {
     single { LocationStateReceiver() }
     single { BluetoothStateReceiver() }
+    single { ScreenStateReceiver() }
     single { BatterSaverStateReceiver() }
     single { FirebaseAnalytics.getInstance(androidApplication()) }
     single { WakeLockManager(androidContext().getSystemService()) }
     single { androidContext().getSystemService<PowerManager>() }
     single { androidContext().getSystemService<BluetoothManager>() }
 }
-
 
 
 val allModules = listOf(appModule, viewModelModule, databaseModule, repositoryModule)

--- a/app/src/main/kotlin/cz/covid19cz/app/bt/BluetoothRepository.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/bt/BluetoothRepository.kt
@@ -7,9 +7,8 @@ import android.bluetooth.le.AdvertiseSettings
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.ParcelUuid
-import android.util.Log
-import androidx.core.content.getSystemService
 import androidx.databinding.ObservableArrayList
+import androidx.lifecycle.MutableLiveData
 import com.polidea.rxandroidble2.RxBleClient
 import com.polidea.rxandroidble2.scan.ScanFilter
 import com.polidea.rxandroidble2.scan.ScanResult
@@ -25,7 +24,6 @@ import cz.covid19cz.app.utils.L
 import cz.covid19cz.app.utils.isBluetoothEnabled
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
-import java.nio.charset.Charset
 import java.util.*
 import kotlin.collections.HashMap
 
@@ -129,10 +127,14 @@ class BluetoothRepository(
         return btManager.isBluetoothEnabled()
     }
 
-    fun startScanning() {
+    val lastScanResultTime: MutableLiveData<Long> = MutableLiveData(0)
+
+    fun startScanning(useScanFilter: Boolean = true) {
         if (isScanning) {
             stopScanning()
         }
+
+        L.d("Starting BLE scanning ${if (useScanFilter) "with" else "without"} filter")
 
         if (!isBtEnabled()) {
             L.d("Bluetooth disabled, can't start scanning")
@@ -143,14 +145,17 @@ class BluetoothRepository(
 
         // "Some" scan filter needed for background scanning since Android 8.1.
         // However, some devices (at least Samsung S10e...) consider empty filter == no filter.
-        //TODO: We have to solve this using some list of problematic devices
-        val builder = ScanFilter.Builder()
-        builder.setServiceUuid(ParcelUuid(SERVICE_UUID))
-        val scanFilter = builder.build()
+        val scanFilter: ScanFilter = if (useScanFilter) {
+            val builder = ScanFilter.Builder()
+            builder.setServiceUuid(ParcelUuid(SERVICE_UUID))
+            builder.build()
+        } else {
+            ScanFilter.Builder().build()
+        }
 
         scanDisposable = rxBleClient.scanBleDevices(
             ScanSettings.Builder().setScanMode(AppConfig.scanMode).build(),
-            ScanFilter.Builder().build()
+            scanFilter
         ).subscribe({ scanResult ->
             onScanResult(scanResult)
         }, {
@@ -175,18 +180,22 @@ class BluetoothRepository(
             .map { tempArray ->
                 for (item in tempArray) {
                     item.calculate()
-                    db.add(
-                        ScanResultEntity(
-                            0,
-                            item.deviceId,
-                            item.timestampStart,
-                            item.timestampEnd,
-                            item.maxRssi,
-                            item.medRssi,
-                            item.rssiCount
-                        )
+
+                    val scanResult = ScanResultEntity(
+                        0,
+                        item.deviceId,
+                        item.timestampStart,
+                        item.timestampEnd,
+                        item.maxRssi,
+                        item.medRssi,
+                        item.rssiCount
                     )
+
+                    L.d("Saving: $scanResult")
+
+                    db.add(scanResult)
                 }
+
                 tempArray.size
             }.execute({
                 L.d("$it records saved")
@@ -195,9 +204,10 @@ class BluetoothRepository(
     }
 
     private fun onScanResult(result: ScanResult) {
-        if (result.scanRecord?.serviceUuids?.contains(ParcelUuid(SERVICE_UUID)) == true) {
+        lastScanResultTime.value = System.currentTimeMillis()
 
-            var deviceId = getBuidFromAndroid(result.scanRecord.bytes)
+        if (result.scanRecord?.serviceUuids?.contains(ParcelUuid(SERVICE_UUID)) == true) {
+            val deviceId = getBuidFromAndroid(result.scanRecord.bytes)
 
             if (deviceId == null && result.scanRecord.getManufacturerSpecificData(0x004C) != null) {
                 // It's time to handle iOS Device
@@ -219,7 +229,7 @@ class BluetoothRepository(
 
                 scanResultsMap[deviceId]?.let { entity ->
                     entity.addRssi(result.rssi)
-                    L.d("Found existing device: $deviceId")
+                    L.d("Device $deviceId RSSI ${result.rssi}")
                 }
             }
         }
@@ -232,13 +242,12 @@ class BluetoothRepository(
         L.d("Connecting to GATT")
         discoveredIosDevices[mac] = session
 
-        val device = btManager?.adapter?.getRemoteDevice(mac)
+        val device = btManager.adapter?.getRemoteDevice(mac)
         device?.connectGatt(context, false, gattCallback)
     }
 
     private fun getBuidFromAndroid(bytes: ByteArray): String? {
-
-        var result = ByteArray(10)
+        val result = ByteArray(10)
 
         var currIndex = 0
         var len = -1
@@ -277,7 +286,7 @@ class BluetoothRepository(
     }
 
     fun supportsAdvertising(): Boolean {
-        return btManager?.adapter?.isMultipleAdvertisementSupported ?: false
+        return btManager.adapter?.isMultipleAdvertisementSupported ?: false
     }
 
     fun startAdvertising(buid: String) {
@@ -311,7 +320,7 @@ class BluetoothRepository(
         val scanData = AdvertiseData.Builder()
             .addServiceData(parcelUuid, buid.hexAsByteArray).build()
 
-        btManager?.adapter?.bluetoothLeAdvertiser?.startAdvertising(
+        btManager.adapter?.bluetoothLeAdvertiser?.startAdvertising(
             settings,
             data,
             scanData,
@@ -322,6 +331,6 @@ class BluetoothRepository(
     fun stopAdvertising() {
         L.d("Stopping BLE advertising")
         isAdvertising = false
-        btManager?.adapter?.bluetoothLeAdvertiser?.stopAdvertising(advertisingCallback)
+        btManager.adapter?.bluetoothLeAdvertiser?.stopAdvertising(advertisingCallback)
     }
 }

--- a/app/src/main/kotlin/cz/covid19cz/app/receiver/ScreenStateReceiver.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/receiver/ScreenStateReceiver.kt
@@ -1,0 +1,19 @@
+package cz.covid19cz.app.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import cz.covid19cz.app.service.CovidService
+
+class ScreenStateReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        intent?.action?.let { action ->
+            when (action) {
+                Intent.ACTION_SCREEN_OFF, Intent.ACTION_SCREEN_ON -> CovidService.screenStateChange(
+                    context,
+                    action
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/cz/covid19cz/app/service/CovidService.kt
+++ b/app/src/main/kotlin/cz/covid19cz/app/service/CovidService.kt
@@ -16,6 +16,7 @@ import cz.covid19cz.app.ext.isLocationEnabled
 import cz.covid19cz.app.receiver.BatterSaverStateReceiver
 import cz.covid19cz.app.receiver.BluetoothStateReceiver
 import cz.covid19cz.app.receiver.LocationStateReceiver
+import cz.covid19cz.app.receiver.ScreenStateReceiver
 import cz.covid19cz.app.ui.notifications.CovidNotificationManager
 import cz.covid19cz.app.utils.L
 import io.reactivex.Observable
@@ -23,35 +24,48 @@ import io.reactivex.disposables.Disposable
 import org.koin.android.ext.android.inject
 import java.util.concurrent.TimeUnit
 
+
 class CovidService : Service() {
 
     companion object {
         const val ACTION_START = "ACTION_START"
         const val ACTION_STOP = "ACTION_STOP"
         const val ACTION_UPDATE = "ACTION_UPDATE"
+        const val ACTION_SCREEN_STATE_CHANGE = "ACTION_SCREEN_STATE_CHANGE"
+
+        const val EXTRA_SCREEN_STATE = "SCREEN_STATE"
+
 
         fun startService(c: Context) {
-            val serviceIntent = Intent(c, CovidService::class.java)
-            serviceIntent.action = ACTION_START
-            ContextCompat.startForegroundService(c, serviceIntent)
+            val intent = Intent(c, CovidService::class.java)
+            intent.action = ACTION_START
+            ContextCompat.startForegroundService(c, intent)
         }
 
         fun stopService(c: Context) {
-            val stopIntent = Intent(c, CovidService::class.java)
-            stopIntent.action = ACTION_STOP
-            c.startService(stopIntent)
+            val intent = Intent(c, CovidService::class.java)
+            intent.action = ACTION_STOP
+            c.startService(intent)
         }
 
         fun update(c: Context) {
-            val stopIntent = Intent(c, CovidService::class.java)
-            stopIntent.action = ACTION_UPDATE
-            c.startService(stopIntent)
+            val intent = Intent(c, CovidService::class.java)
+            intent.action = ACTION_UPDATE
+            c.startService(intent)
+        }
+
+        fun screenStateChange(c: Context, newState: String) {
+            val intent = Intent(c, CovidService::class.java)
+            intent.action = ACTION_SCREEN_STATE_CHANGE
+            intent.putExtra(EXTRA_SCREEN_STATE, newState)
+            c.startService(intent)
         }
     }
 
     private val locationStateReceiver by inject<LocationStateReceiver>()
     private val bluetoothStateReceiver by inject<BluetoothStateReceiver>()
     private val batterySaverStateReceiver by inject<BatterSaverStateReceiver>()
+    private val screenStateReceiver by inject<ScreenStateReceiver>()
     private val btUtils by inject<BluetoothRepository>()
     private val prefs by inject<SharedPrefsRepository>()
     private val wakeLockManager by inject<WakeLockManager>()
@@ -62,6 +76,9 @@ class CovidService : Service() {
     private var bleScanningDisposable: Disposable? = null
 
     private lateinit var deviceBuid: String
+    private var useScanFilter: Boolean = false
+
+    private var screenOfDetectionTimer: CountDownTimer? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -89,6 +106,14 @@ class CovidService : Service() {
                     turnMaskOn()
                 } else {
                     turnMaskOff()
+                }
+            }
+            ACTION_SCREEN_STATE_CHANGE -> {
+                L.d("Screen state change: ${intent.getStringExtra(EXTRA_SCREEN_STATE)}")
+
+                when (intent.getStringExtra(EXTRA_SCREEN_STATE)) {
+                    Intent.ACTION_SCREEN_OFF -> startScreenOffScanningCheck()
+                    Intent.ACTION_SCREEN_ON -> screenOfDetectionTimer?.cancel()
                 }
             }
         }
@@ -141,19 +166,24 @@ class CovidService : Service() {
 
         val batterySaverFilter = IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
         registerReceiver(batterySaverStateReceiver, batterySaverFilter)
+
+        val screenStateFilter = IntentFilter(Intent.ACTION_SCREEN_OFF)
+        screenStateFilter.addAction(Intent.ACTION_SCREEN_ON)
+        registerReceiver(screenStateReceiver, screenStateFilter)
     }
 
     private fun unsubscribeFromReceivers() {
         unregisterReceiver(locationStateReceiver)
         unregisterReceiver(bluetoothStateReceiver)
         unregisterReceiver(batterySaverStateReceiver)
+        unregisterReceiver(screenStateReceiver)
     }
 
     private fun startBleScanning() {
         bleScanningDisposable = Observable.just(true)
             .map {
                 if (btUtils.isBtEnabled() && isLocationEnabled()) {
-                    btUtils.startScanning()
+                    btUtils.startScanning(useScanFilter)
                 } else {
                     bleScanningDisposable?.dispose()
                 }
@@ -161,6 +191,7 @@ class CovidService : Service() {
             .delay(AppConfig.collectionSeconds, TimeUnit.SECONDS)
             .map {
                 btUtils.stopScanning()
+                screenOfDetectionTimer?.cancel()
             }
             .delay(AppConfig.waitingSeconds, TimeUnit.SECONDS)
             .repeat()
@@ -193,6 +224,40 @@ class CovidService : Service() {
             powerManager.locationPowerSaveMode == PowerManager.LOCATION_MODE_ALL_DISABLED_WHEN_SCREEN_OFF
         } else {
             true
+        }
+    }
+
+    /**
+     * Starts regular check to ensure we're reading data when the screen is off.
+     */
+    private fun startScreenOffScanningCheck() {
+        Handler(Looper.getMainLooper()).post {
+            val switchedOffSince = System.currentTimeMillis()
+
+            /**
+             * Wait up-to 30s, try every 10 seconds.
+             * If the check passes, this timer is stopped.
+             * If onFinish is invoked, it means the test didn't passed => we have to restart scanning.
+             */
+            screenOfDetectionTimer =
+                object : CountDownTimer(30 * 1000, 10 * 1000) {
+                    override fun onTick(millisUntilFinished: Long) {
+                        btUtils.lastScanResultTime.value?.let { lastResultTime ->
+                            L.d("Checking if it's still scanning")
+                            if (lastResultTime > switchedOffSince + 1000) { // 1s tolerance
+                                // Device does support scanning on background with empty filter
+                                screenOfDetectionTimer?.cancel() // cancel this check, it's not needed anymore
+                            }
+                        }
+                    }
+
+                    override fun onFinish() {
+                        L.d("Device does NOT support scanning on background with empty filter, restarting")
+                        useScanFilter = true
+                        btUtils.stopScanning()
+                        btUtils.startScanning(useScanFilter = true)
+                    }
+                }.start()
         }
     }
 }


### PR DESCRIPTION
Auto-detection of device behavior when it considers empty filter as no filter.

When `SCREEN_OFF` event is received, it invokes a check if the BT scan is still working (receiving data).

Questions are checking interval and max. time of waiting since `BALLANCED` power settings could deliver results e.g. only once per 10s. However, current times would still work (problem would be if it goes over the absolute limit, currently 30s).